### PR TITLE
Synthesized shades

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -67,9 +67,9 @@ version = "3.5.1+1"
 
 [[deps.ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "1ee88c4c76caa995a885dc2f22a5d548dfbbc0ba"
+git-tree-sha1 = "81f0cb60dc994ca17f68d9fb7c942a5ae70d9ee4"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.2.2"
+version = "5.0.8"
 
 [[deps.Arrow]]
 deps = ["ArrowTypes", "BitIntegers", "CodecLz4", "CodecZstd", "DataAPI", "Dates", "Mmap", "PooledArrays", "SentinelArrays", "Tables", "TimeZones", "UUIDs"]
@@ -137,9 +137,9 @@ version = "0.4.2"
 
 [[deps.CPUSummary]]
 deps = ["CpuId", "IfElse", "Static"]
-git-tree-sha1 = "baaac45b4462b3b0be16726f38b789bf330fcb7a"
+git-tree-sha1 = "0eaf4aedad5ccc3e39481db55d72973f856dc564"
 uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
-version = "0.1.21"
+version = "0.1.22"
 
 [[deps.CSV]]
 deps = ["Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
@@ -172,9 +172,9 @@ version = "0.3.10"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "9950387274246d08af38f6eef8cb5480862a435f"
+git-tree-sha1 = "9489214b993cd42d17f44c36e359bf6a7c919abf"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.14.0"
+version = "1.15.0"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
@@ -184,9 +184,9 @@ version = "0.1.3"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]
-git-tree-sha1 = "f576084239e6bdf801007c80e27e2cc2cd963fe0"
+git-tree-sha1 = "eb61d6b97041496058245821e3bb7eba2b2cf4db"
 uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
-version = "0.1.6"
+version = "0.1.8"
 
 [[deps.Clustering]]
 deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "SparseArrays", "Statistics", "StatsBase"]
@@ -232,15 +232,15 @@ version = "3.17.1"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "63d1e802de0c4882c00aee5cb16f9dd4d6d7c59c"
+git-tree-sha1 = "0f4e115f6f34bbe43c19751c90a38b2f380637b9"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.1"
+version = "0.11.3"
 
 [[deps.ColorVectorSpace]]
 deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "SpecialFunctions", "Statistics", "TensorCore"]
-git-tree-sha1 = "3f1f500312161f1ae067abe07d13b40f78f32e07"
+git-tree-sha1 = "d08c20eef1f2cbc6e60fd3612ac4340b89fea322"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.9.8"
+version = "0.9.9"
 
 [[deps.Colors]]
 deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
@@ -256,9 +256,9 @@ version = "0.3.0"
 
 [[deps.Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b153278a25dd42c65abbf4e62344f9d22e59191b"
+git-tree-sha1 = "9be8be1d8a6f44b96482c8af52238ea7987da3e3"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.43.0"
+version = "3.45.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -318,9 +318,9 @@ version = "1.3.3"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "cc1a8e22627f33c789ab60b36a9132ac050bbf75"
+git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.12"
+version = "0.18.13"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -367,9 +367,9 @@ version = "1.11.0"
 
 [[deps.DimensionalData]]
 deps = ["Adapt", "ArrayInterface", "ConstructionBase", "Dates", "IntervalSets", "LinearAlgebra", "Random", "RecipesBase", "SparseArrays", "Statistics", "Tables"]
-git-tree-sha1 = "40bf62b8912fbe675c2f11ec6ba491e67ae4d5d9"
+git-tree-sha1 = "39fc45e7137662c06d34a230d5707caa30471a6f"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
-version = "0.20.4"
+version = "0.20.7"
 
 [[deps.Distances]]
 deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
@@ -417,9 +417,9 @@ version = "2.2.3+0"
 
 [[deps.EllipsisNotation]]
 deps = ["ArrayInterface"]
-git-tree-sha1 = "d064b0340db45d48893e7604ec95e7a2dc9da904"
+git-tree-sha1 = "03b753748fd193a7f2730c02d880da27c5a24508"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -520,9 +520,9 @@ version = "0.4.2"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "89cc49bf5819f0a10a7a3c38885e7c7ee048de57"
+git-tree-sha1 = "2f18915445b248731ec5db4e4a17e451020bf21e"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.29"
+version = "0.10.30"
 
 [[deps.FreeType]]
 deps = ["CEnum", "FreeType2_jll"]
@@ -560,15 +560,15 @@ version = "3.3.6+0"
 
 [[deps.GR]]
 deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "af237c08bda486b74318c8070adb96efa6952530"
+git-tree-sha1 = "c98aea696662d09e215ef7cda5296024a9646c75"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.64.2"
+version = "0.64.4"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "cd6efcf9dc746b06709df14e462f0a3fe0786b1e"
+git-tree-sha1 = "3a233eeeb2ca45842fe100e0413936834215abf5"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.64.2+0"
+version = "0.64.4+0"
 
 [[deps.GTK3_jll]]
 deps = ["ATK_jll", "Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Libepoxy_jll", "Pango_jll", "Pkg", "Wayland_jll", "Xorg_libX11_jll", "Xorg_libXcomposite_jll", "Xorg_libXcursor_jll", "Xorg_libXdamage_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "Xorg_libXrender_jll", "at_spi2_atk_jll", "gdk_pixbuf_jll", "iso_codes_jll", "xkbcommon_jll"]
@@ -613,9 +613,9 @@ version = "0.5.9"
 
 [[deps.Graphics]]
 deps = ["Colors", "LinearAlgebra", "NaNMath"]
-git-tree-sha1 = "1c5a84319923bea76fa145d49e93aa4394c73fc2"
+git-tree-sha1 = "d61890399bc535850c4bf08e4e0d3a7ad0f21cbd"
 uuid = "a2bd30eb-e257-5431-a919-1863eab51364"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Graphite2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -625,9 +625,9 @@ version = "1.3.14+0"
 
 [[deps.Graphs]]
 deps = ["ArnoldiMethod", "Compat", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
-git-tree-sha1 = "57c021de207e234108a6f1454003120a1bf350c4"
+git-tree-sha1 = "4888af84657011a65afc7a564918d281612f983a"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
@@ -670,18 +670,6 @@ git-tree-sha1 = "18be5268cf415b5e27f34980ed25a7d34261aa83"
 uuid = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
 version = "0.1.7"
 
-[[deps.Hwloc]]
-deps = ["Hwloc_jll"]
-git-tree-sha1 = "92d99146066c5c6888d5a3abc871e6a214388b91"
-uuid = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
-version = "2.0.0"
-
-[[deps.Hwloc_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "303d70c961317c4c20fafaf5dbe0e6d610c38542"
-uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.7.1+0"
-
 [[deps.IfElse]]
 git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
 uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
@@ -694,10 +682,10 @@ uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 version = "0.9.3"
 
 [[deps.ImageIO]]
-deps = ["FileIO", "IndirectArrays", "JpegTurbo", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs"]
-git-tree-sha1 = "539682309e12265fbe75de8d83560c307af975bd"
+deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs"]
+git-tree-sha1 = "d9a03ffc2f6650bd4c831b285637929d99a4efb5"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
-version = "0.6.2"
+version = "0.6.5"
 
 [[deps.Imath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -750,9 +738,9 @@ version = "0.5.4"
 
 [[deps.InverseFunctions]]
 deps = ["Test"]
-git-tree-sha1 = "336cc738f03e069ef2cac55a104eb823455dca75"
+git-tree-sha1 = "b3364212fb5d870f724876ffcd34dd8ec6d98918"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.4"
+version = "0.1.7"
 
 [[deps.InvertedIndices]]
 git-tree-sha1 = "bee5f1ef5bf65df56bdd2e40447590b272a5471f"
@@ -865,13 +853,18 @@ version = "0.15.15"
 
 [[deps.LayoutPointers]]
 deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static"]
-git-tree-sha1 = "b651f573812d6c36c22c944dd66ef3ab2283dfa1"
+git-tree-sha1 = "9e72f9e890c46081dbc0ebeaf6ccaffe16e51626"
 uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
-version = "0.1.6"
+version = "0.1.8"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[deps.LazyModules]]
+git-tree-sha1 = "a560dd966b386ac9ae60bdd3a3d3a326062d3c3e"
+uuid = "8cdb02fc-e678-4876-92c5-9defec4f444e"
+version = "0.3.1"
 
 [[deps.LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
@@ -954,9 +947,9 @@ version = "2.52.4+0"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "c9551dd26e31ab17b86cbd00c2ede019c08758eb"
+git-tree-sha1 = "3eb79b0ca5764d4799c06699573fd8f533259713"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.3.0+1"
+version = "4.4.0+0"
 
 [[deps.Libuuid_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -985,9 +978,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LoopVectorization]]
 deps = ["ArrayInterface", "CPUSummary", "ChainRulesCore", "CloseOpenIntervals", "DocStringExtensions", "ForwardDiff", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "SIMDDualNumbers", "SLEEFPirates", "SpecialFunctions", "Static", "ThreadingUtilities", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "4acc35e95bf18de5e9562d27735bef0950f2ed74"
+git-tree-sha1 = "4392c19f0203df81512b6790a0a67446650bdce0"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.12.108"
+version = "0.12.110"
 
 [[deps.LoweredCodeUtils]]
 deps = ["JuliaInterpreter"]
@@ -1152,9 +1145,9 @@ version = "0.4.0"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "aee446d0b3d5764e35289762f6a18e8ea041a592"
+git-tree-sha1 = "b4975062de00106132d0b01b5962c09f7db7d880"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.11.0"
+version = "1.12.5"
 
 [[deps.Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1231,9 +1224,9 @@ version = "8.44.0+0"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "027185efff6be268abbaf30cfd53ca9b59e3c857"
+git-tree-sha1 = "3e32c8dbbbe1159a5057c80b8a463369a78dd8d8"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.10"
+version = "0.11.12"
 
 [[deps.PNGFiles]]
 deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
@@ -1459,9 +1452,9 @@ version = "3.4.1"
 
 [[deps.SIMDDualNumbers]]
 deps = ["ForwardDiff", "IfElse", "SLEEFPirates", "VectorizationBase"]
-git-tree-sha1 = "62c2da6eb66de8bb88081d20528647140d4daa0e"
+git-tree-sha1 = "dd4195d308df24f33fb10dde7c22103ba88887fa"
 uuid = "3cdde19b-5bb0-4aaf-8931-af3e248e098b"
-version = "0.1.0"
+version = "0.1.1"
 
 [[deps.SIMDTypes]]
 git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
@@ -1476,9 +1469,9 @@ version = "0.6.32"
 
 [[deps.ScanByte]]
 deps = ["Libdl", "SIMD"]
-git-tree-sha1 = "9cc2955f2a254b18be655a4ee70bc4031b2b189e"
+git-tree-sha1 = "c49318f1b9ca3d927ae576d323fa6f724d01ba53"
 uuid = "7b38b023-a4d7-4c5e-8d43-3f3097f304eb"
-version = "0.3.0"
+version = "0.3.1"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1488,9 +1481,9 @@ version = "1.1.0"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
-git-tree-sha1 = "6a2f7d70512d205ca8c7ee31bfa9f142fe74310c"
+git-tree-sha1 = "db8481cf5d6278a121184809e9eb1628943c7704"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.3.12"
+version = "1.3.13"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -1544,9 +1537,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "5ba658aeecaaf96923dce0da9e703bd1fe7666f9"
+git-tree-sha1 = "a9e798cae4867e3a41cae2dd9eb60c047f1212db"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.4"
+version = "2.1.6"
 
 [[deps.StableRNGs]]
 deps = ["Random", "Test"]
@@ -1562,9 +1555,9 @@ version = "0.1.1"
 
 [[deps.Static]]
 deps = ["IfElse"]
-git-tree-sha1 = "7f5a513baec6f122401abfc8e9c074fdac54f6c1"
+git-tree-sha1 = "5d2c08cef80c7a3a8ba9ca023031a85c263012c5"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.4.1"
+version = "0.6.6"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
@@ -1578,9 +1571,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c82aaa13b44ea00134f8c9c89819477bd3986ecd"
+git-tree-sha1 = "2c11d7290036fe7aac9038ff312d3b3a2a5bf89e"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
@@ -1602,9 +1595,9 @@ version = "0.14.33"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
-git-tree-sha1 = "e75d82493681dfd884a357952bbd7ab0608e1dc3"
+git-tree-sha1 = "9abba8f8fb8458e9adf07c8a2377a070674a24f1"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.7"
+version = "0.6.8"
 
 [[deps.SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
@@ -1716,10 +1709,10 @@ uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 version = "0.1.2"
 
 [[deps.VectorizationBase]]
-deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "Hwloc", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "ff34c2f1d80ccb4f359df43ed65d6f90cb70b323"
+deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
+git-tree-sha1 = "c95d242ade2d67c1510ce52d107cfca7a83e0b4e"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.31"
+version = "0.21.33"
 
 [[deps.Wayland_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
@@ -1753,9 +1746,9 @@ version = "0.5.5"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+git-tree-sha1 = "58443b63fb7e465a8a7210828c91c08b92132dff"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.9.14+0"
 
 [[deps.XSLT_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]

--- a/scripts/LearnTry/Benchmarks/MaxLesions.jl
+++ b/scripts/LearnTry/Benchmarks/MaxLesions.jl
@@ -24,7 +24,7 @@ tadf, tmdf = dummyrun_spatialrust(10, 100, 10)
 
 using BenchmarkTools
 Random.seed!(1234)
-@btime a, m = dummyrun_spatialrust(1600, 100, 25)
+@btime a, m = dummyrun_spatialrust(1000, 100, 25)
 
 
 maxlesions = [1, 5, 10, 25, 50]

--- a/src/ABM/Setup.jl
+++ b/src/ABM/Setup.jl
@@ -1,14 +1,15 @@
-
-export Shade, Coffee, Rust
+# "Commit Stuff, then use shade_map in wind dispersal"
+export Coffee, Rust
 
 Base.@kwdef mutable struct Books
     days::Int = 0 # same as ticks unless start_days_at != 0
     ticks::Int = 0
     cycle::Vector{Int} = [0]
     coffee_ids::Vector{Int} = Int[]
-    shade_ids::Vector{Int} = Int[]
+    # shade_ids::Vector{Int} = Int[]
     rust_ids::Vector{Int} = Int[]
-    # ind_shade::Float64 = 0.0
+    ind_shade::Float64 = 0.0
+    n_shades::Int = 0
     outpour::Float64 = 0.0
     #temp_var::Float64 = 0.0
     temperature:: Float64 = 0.0
@@ -30,9 +31,9 @@ struct Props
     # weather time-series
     weather::Weather
     # farm map
-    # farm_map::Array{Int,2}
+    farm_map::Array{Int,2}
     # shade map
-    # shade_map::Array{Int, 2}
+    shade_map::Array{Float64, 2}
 end
 
 ## Agent types and constructor fcts
@@ -143,20 +144,48 @@ end
 
 ## Setup functions
 
-function add_trees!(model::ABM, farm_map::Array{Int,2}, start_days_at::Int)
-#     cof_pos = findall(x -> x == 1, farm_map)
-#     for (c,pos) in enumerate(cof_pos)
-#         push!(model.current.coffee_ids, add_agent!(Tuple(pos), Coffee, model; production = start_days_at).id)
-#     end
-# end
-    for patch in positions(model)
-        if farm_map[patch...] == 1
-            push!(model.current.coffee_ids, add_agent!(patch, Coffee, model).id) # push! works because add_agent! returns the new agent
-        # elseif farm_map == 2
-        #     push!(model.current.shade_ids, add_agent!(patch, Shade, model; shade = model.pars.target_shade).id)
+function update_shade_map!(model)
+    shades = Tuple.(findall(x -> x ==2, model.farm_map))
+    shade_map = zeros(size(model.farm_map))
+    for sh in shades
+        shade_map[sh...] += 1.0
+        neighs = nearby_positions(sh, model, model.pars.shade_r)
+        for n in neighs
+            shade_map[n...] += 1 / shade_dist(sh, n)
         end
+        # "ver como se normaliza"
+    end
+    shade_map = min.(1.0, shade_map)
+    # model.shade_map .*= 0
+    model.shade_map .+= shade_map
+end
+
+function shade_dist(pos1::CartesianIndex, pos2::CartesianIndex)
+    caths = pos1 - pos2
+    dist = sqrt(caths[1]^2 + caths[2]^2)
+    return dist + 0.05
+end
+
+function shade_dist(pos1::Tuple, pos2::Tuple)
+    caths = pos1 .- pos2
+    dist = sqrt(caths[1]^2 + caths[2]^2)
+    return dist + 0.05
+end
+
+function add_trees!(model::ABM, farm_map::Array{Int,2}, start_days_at::Int)
+    cof_pos = Tuple.(findall(x -> x == 1, farm_map))
+    for (c,pos) in enumerate(cof_pos)
+        push!(model.current.coffee_ids, add_agent!(pos, Coffee, model; production = start_days_at).id)
     end
 end
+    # for patch in positions(model)
+    #     if farm_map[patch...] == 1
+    #         push!(model.current.coffee_ids, add_agent!(patch, Coffee, model).id) # push! works because add_agent! returns the new agent
+    #     elseif farm_map == 2
+    #         push!(model.current.shade_ids, add_agent!(patch, Shade, model; shade = model.pars.target_shade).id)
+    #     end
+    # end
+# end
 
 # function add_trees!(model::ABM, farm_map::Array{Int,2}, start_days_at::Int)
 #     cycle_adv = mod(start_days_at, model.pars.harvest_cycle) # how advanced in the harvest cycle are we
@@ -171,16 +200,16 @@ end
 #     end
 # end
 
-function count_shades!(model::ABM)
-    # shade_map = shade_map(model.farm_map)
-    # for c in allagents(model)
-    #
-    # end
-    for c in model.current.coffee_ids
-        neighbors = nearby_ids(model[c], model, model.pars.shade_r) # get ids of neighboring plants
-        model[c].shade_neighbors = collect(Iterators.Filter(id -> model[id] isa Shade, neighbors))
-    end
-end
+# function count_shades!(model::ABM)
+#     # shade_map = shade_map(model.farm_map)
+#     # for c in allagents(model)
+#     #
+#     # end
+#     for c in model.current.coffee_ids
+#         neighbors = nearby_ids(model[c], model, model.pars.shade_r) # get ids of neighboring plants
+#         model[c].shade_neighbors = collect(Iterators.Filter(id -> model[id] isa Shade, neighbors))
+#     end
+# end
 
 function init_rusts!(model::ABM, ini_rusts::Float64) # inoculate coffee plants
     if ini_rusts < 1.0
@@ -238,12 +267,12 @@ function init_abm_obj(parameters::Parameters, farm_map::Array{Int,2}, weather::W
     if parameters.start_days_at <= 132
         properties = Props(parameters, Books(days = parameters.start_days_at,
         # ind_shade = parameters.target_shade,
-        ), weather)
+        ), weather, farm_map, zeros(size(farm_map)))
     else
         properties = Props(parameters, Books(days = parameters.start_days_at,
         # ind_shade = parameters.target_shade,
         # ticks = ?,
-        cycle = [4]), weather)
+        cycle = [4]), weather, farm_map, zeros(size(farm_map)))
     end
 
     model = ABM(Union{Coffee, Rust}, space; properties = properties, warn = false)
@@ -254,9 +283,11 @@ function init_abm_obj(parameters::Parameters, farm_map::Array{Int,2}, weather::W
         # , cycle = [4]), weather),
         #     warn = false)
 
+    update_shade_map!(model)
+
     add_trees!(model, farm_map, parameters.start_days_at)
 
-    count_shades!(model)
+    # count_shades!(model)
 
     init_rusts!(model, parameters.ini_rusts)
 

--- a/src/ABM/Setup.jl
+++ b/src/ABM/Setup.jl
@@ -1,4 +1,3 @@
-# "Commit Stuff, then use shade_map in wind dispersal"
 export Coffee, Rust
 
 Base.@kwdef mutable struct Books

--- a/src/ABM/ShadeSteps.jl
+++ b/src/ABM/ShadeSteps.jl
@@ -1,17 +1,23 @@
 function prune_shades!(model::ABM)
-    for shade_i in model.current.shade_ids
-        @inbounds model[shade_i].shade = model.pars.target_shade
-    end
-    model.current.costs += length(model.current.shade_ids) * model.pars.prune_cost
+    # for shade_i in model.current.shade_ids
+    #     @inbounds model[shade_i].shade = model.pars.target_shade
+    # end
+    # model.current.costs += length(model.current.shade_ids) * model.pars.prune_cost
+
+
+    model.current.ind_shade = model.pars.target_shade
+    model.current.costs = model.current.n_shades * model.pars.prune_cost
 end
 
 function grow_shades!(model::ABM)
-    for shade_i in model.current.shade_ids
-        grow_shade!(tree, model.pars.shade_g_rate)
-    end
+    # for shade_i in model.current.shade_ids
+    #     grow_shade!(tree, model.pars.shade_g_rate)
+    # end
+    model.current.ind_shade += model.pars.shade_g_rate * 
+        (1.0 - model.current.ind_shade / 0.95) * model.current.ind_shade
 end
 
-function grow_shade!(tree::Shade, rate::Float64)
-    tree.shade += tree.shade + rate * (1.0 - tree.shade / 0.95) * tree.shade
-    tree.age += 1
-end
+# function grow_shade!(tree::Shade, rate::Float64)
+#     tree.shade += rate * (1.0 - tree.shade / 0.95) * tree.shade
+#     tree.age += 1
+# end

--- a/src/ABM/Step.jl
+++ b/src/ABM/Step.jl
@@ -152,20 +152,20 @@ end
 
 ## Step contents for inds
 
-function coffee_harvest_step!(model::ABM, coffee::Coffee)
-    if coffee.exh_countdown > 1
-        coffee.exh_countdown -= 1
-    elseif coffee.exh_countdown == 1
-        coffee.area = 1.0
-        coffee.exh_countdown = 0
-    else
-        !isempty(coffee.shade_neighbors) && update_sunlight!(model, coffee)
-        grow_coffee!(coffee, model.pars.cof_gr)
-        acc_production!(coffee)
-    end
-    model.current.prod += coffee.production / model.pars.harvest_cycle
-    coffee.production = 1.0
-end
+# function coffee_harvest_step!(model::ABM, coffee::Coffee)
+#     if coffee.exh_countdown > 1
+#         coffee.exh_countdown -= 1
+#     elseif coffee.exh_countdown == 1
+#         coffee.area = 1.0
+#         coffee.exh_countdown = 0
+#     else
+#         !isempty(coffee.shade_neighbors) && update_sunlight!(model, coffee)
+#         grow_coffee!(coffee, model.pars.cof_gr)
+#         acc_production!(coffee)
+#     end
+#     model.current.prod += coffee.production / model.pars.harvest_cycle
+#     coffee.production = 1.0
+# end
 
 function coffee_nh_step!(model::ABM, coffee::Coffee)
     if coffee.exh_countdown > 1
@@ -174,7 +174,8 @@ function coffee_nh_step!(model::ABM, coffee::Coffee)
         coffee.area = 1.0
         coffee.exh_countdown = 0
     else
-        !isempty(coffee.shade_neighbors) && update_sunlight!(model, coffee)
+        # !isempty(coffee.shade_neighbors) &&
+        update_sunlight!(model, coffee)
         grow_coffee!(coffee, model.pars.cof_gr)
         acc_production!(coffee)
     end
@@ -236,8 +237,10 @@ function update_sunlight!(model::ABM, cof::Coffee)
     # shades::Array{Float64} = getproperty.(model[cof.shade_neighbors],:shade)
     # shade = sum(shades)
 
-    @inbounds cof.sunlight = 1.0 - sum(getproperty.((model[s] for s in cof.shade_neighbors), :shade)) / (((model.pars.shade_r * 2.0) + 1.0)^2.0 - 1.0)
+    # @inbounds cof.sunlight = 1.0 - sum(getproperty.((model[s] for s in cof.shade_neighbors), :shade)) / (((model.pars.shade_r * 2.0) + 1.0)^2.0 - 1.0)
     # cof.sunlight = exp(-(sum(cof.shade_neighbors.shade) / 8))
+
+    cof.sunlight = model.shade_map[cof.pos...] * (1 - model.current.ind_shade)
 end
 
 function grow_coffee!(cof::Coffee, cof_gr)

--- a/src/QuickRuns.jl
+++ b/src/QuickRuns.jl
@@ -2,8 +2,8 @@ export dummyrun_spatialrust, justtwosteps
 
 function dummyrun_spatialrust(steps::Int = 200, side::Int = 60, maxlesions::Int = 25)
     pars = Parameters(steps = steps, map_side = side, max_lesions = maxlesions)
-    model = init_spatialrust(pars, create_fullsun_farm_map(), create_weather(pars.rain_prob, pars.wind_prob, pars.mean_temp, pars.steps))
-    
+    model = init_spatialrust(pars, create_fullsun_farm_map(side), create_weather(pars.rain_prob, pars.wind_prob, pars.mean_temp, pars.steps))
+
     a_df, m_df = run!(model, dummystep, step_model!, steps;
         # adata = [(:n_lesions, median, justrusts), (:state, medsum_s, justrusts), (:production, mean, justcofs)],
         adata = [(:n_lesions, median, justrusts), (:production, mean, justcofs)],
@@ -13,7 +13,7 @@ end
 
 function justtwosteps(side::Int = 60)
     pars = Parameters(steps = 5, map_side = side, max_lesions = 25)
-    model = init_spatialrust(pars, create_fullsun_farm_map())
+    model = init_spatialrust(pars, create_fullsun_farm_map(side))
     step!(model, dummystep, step_model!, 2)
     return model
 end

--- a/src/submodels/ShadeMap.jl
+++ b/src/submodels/ShadeMap.jl
@@ -1,0 +1,71 @@
+using Agents
+
+## Agent types and constructor fcts
+mutable struct Coffee <: AbstractAgent
+    id::Int
+    pos::NTuple{2, Int}
+    area::Float64 # healthy foliar area (= 25 - rust.area * rust.n_lesions/25)
+    sunlight::Float64 # let through by shade trees
+    shade_neighbors::Vector{Int} # remember which neighbors are shade trees
+    progression::Float64
+    production::Float64
+    exh_countdown::Int
+    age::Int
+    hg_id::Int # "host-guest id": coffee is host, then this stores corresponding rust's id
+    sample_cycle::Vector{Int} # vector with cycles where coffee should be sampled
+    #fung_countdown::Int
+end
+
+function dist(pos1::CartesianIndex, pos2::CartesianIndex)
+    caths = pos1 - pos2
+    dist = sqrt(caths[1]^2 + caths[2]^2)
+    return dist + 0.05
+end
+
+function dist(pos1::Tuple, pos2::Tuple)
+    caths = pos1 .- pos2
+    dist = sqrt(caths[1]^2 + caths[2]^2)
+    return dist + 0.05
+end
+side = 100
+farm_map = create_farm_map(Parameters(map_side = side, shade_d = 6, row_d = 2, barrier_arr = (0,0,0,0), barrier_rows = 1))
+# heatmap(farm_map)
+
+myfarmmap = zeros(side,side); myfarmmap[2,2] = 2; myfarmmap[4,4] = 2
+
+tmodel = ABM(Coffee, GridSpace((side, side), periodic = false, metric = :chebyshev); properties = farm_map)
+
+function shade_map!(model, shade_r)
+    shades = Tuple.(findall(x -> x == 2, model.properties))
+    shade_map = zeros(size(model.properties))
+    # counts = zeros(shade_r)
+    for sh in shades
+        # shade_map[sh...] += (shade_r * 2 + 1) ^ 2 - ((shade_r - 1) * 2 + 1) ^ 2
+        shade_map[sh...] += 1.0
+        # counts[sh...] += 1
+        neighs = nearby_positions(sh, model, shade_r)
+        for n in neighs
+            if n ∉ shades
+                # shade_map[n...] += 1 / (maximum(abs.(sh .- n)) + 0.05)
+                # shade_map[n...] += 1
+                shade_map[n...] += (1 / (dist(sh, n)))
+                # counts[n...] += 1
+            end
+        end
+    end
+    shade_map = min.(1.0, shade_map)
+    # shade_map .= shade_map ./ counts
+    # shade_map /= (shade_r * 2 + 1) ^ 2 - ((shade_r - 1) * 2 + 1) ^ 2
+    # model.shade_map .*= 0
+    # model.shade_map .+= shade_map
+    return shade_map
+end
+
+shade_map1 = shade_map!(tmodel, 1)
+shade_map2 = shade_map!(tmodel, 2)
+shade_map3 = shade_map!(tmodel, 3)
+shade_map4 = shade_map!(tmodel, 4)
+
+using Plots
+heatmap(shade_map3)
+heatmap(farm_map)


### PR DESCRIPTION
Trade-off: Model is less flexible (loses ability to track individual shades' state), but execution time is shortened by ~30% (possibly more)
Before: Coffees got shade state from neighboring shades and average them
Now: ind_shade is a global that keeps track of shade growth (same for all shades in farm) and shade_map, generated at setup, provides the amount of "coverage" at each cell grid. At each step, coffees multiply the coverage at their pos by the current ind_shade value to get their current sunlight.
If needed, shade_map could potentially be updated whenever a change in shade arrangement is introduced, but currently the model doesn't implement that option.